### PR TITLE
주문 관리 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+.idea
+
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/com.first-class.msa.orders/build.gradle
+++ b/com.first-class.msa.orders/build.gradle
@@ -22,6 +22,9 @@ ext {
 }
 
 dependencies {
+	// RabbitMQ
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
 	// JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
@@ -42,6 +45,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 dependencyManagement {

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/OrdersApplication.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/OrdersApplication.java
@@ -2,8 +2,12 @@ package com.first_class.msa.orders;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableFeignClients
+@EnableJpaAuditing
 public class OrdersApplication {
 
 	public static void main(String[] args) {

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/AuthSearchConditionDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/AuthSearchConditionDTO.java
@@ -1,0 +1,47 @@
+package com.first_class.msa.orders.application.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthSearchConditionDTO {
+	private Long userId;
+	private Long businessId;
+	private Long hubId;
+	private String userRole;
+	private List<Long> orderIdList;
+
+	public static AuthSearchConditionDTO createForMaster() {
+		return AuthSearchConditionDTO.builder()
+			.userRole("MASTER")
+			.build();
+	}
+
+	public static AuthSearchConditionDTO createForHubManager(Long hubId) {
+		return AuthSearchConditionDTO.builder()
+			.userRole("HUB_MANAGER")
+			.hubId(hubId)
+			.build();
+	}
+
+	public static AuthSearchConditionDTO createForBusinessManager(Long businessId) {
+		return AuthSearchConditionDTO.builder()
+			.userRole("BUSINESS_MANAGER")
+			.businessId(businessId)
+			.build();
+	}
+
+	public static AuthSearchConditionDTO createForDeliveryManager(List<Long> orderIdList) {
+		return AuthSearchConditionDTO.builder()
+			.orderIdList(orderIdList)
+			.userRole("DEFAULT")
+			.build();
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ReqBusinessDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ReqBusinessDTO.java
@@ -1,0 +1,17 @@
+package com.first_class.msa.orders.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReqBusinessDTO {
+	private Long businessId;
+
+	public static ReqBusinessDTO from(Long businessId) {
+		return ReqBusinessDTO
+			.builder()
+			.businessId(businessId)
+			.build();
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResBusinessDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResBusinessDTO.java
@@ -1,0 +1,9 @@
+package com.first_class.msa.orders.application.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ResBusinessDTO {
+	private Long businessId;
+	private Long hubId;
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResBusinessUserDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResBusinessUserDTO.java
@@ -1,0 +1,6 @@
+package com.first_class.msa.orders.application.dto;
+
+public class ResBusinessUserDTO {
+	private Long businessId;
+	private Long userId;
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResDTO.java
@@ -1,0 +1,16 @@
+package com.first_class.msa.orders.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResDTO<T> {
+	private Integer code;
+	private String message;
+	private T data;
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResDeliveryOrderSearchDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResDeliveryOrderSearchDTO.java
@@ -1,0 +1,17 @@
+package com.first_class.msa.orders.application.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResDeliveryOrderSearchDTO {
+	private List<Long> orderIdList;
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResDeliveryOrderSearchDetailDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResDeliveryOrderSearchDetailDTO.java
@@ -1,0 +1,9 @@
+package com.first_class.msa.orders.application.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ResDeliveryOrderSearchDetailDTO {
+	private Long deliveryUserId;
+	private Long orderId;
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResHubDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResHubDTO.java
@@ -1,0 +1,9 @@
+package com.first_class.msa.orders.application.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ResHubDTO {
+	private Long hubId;
+	private Long userId;
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResOrderDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResOrderDTO.java
@@ -1,0 +1,72 @@
+package com.first_class.msa.orders.application.dto;
+
+import java.util.List;
+
+import com.first_class.msa.orders.domain.model.Order;
+import com.first_class.msa.orders.domain.model.OrderLine;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResOrderDTO {
+	private OrderDTO orderDTO;
+
+	public static ResOrderDTO of(Order order){
+		return ResOrderDTO.builder().orderDTO(OrderDTO.from(order)).build();
+	}
+
+	@Getter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class OrderDTO {
+
+		private Long orderId;
+		private String address;
+		private String requestInfo;
+		private Integer orderTotalPrice;
+		private List<OrderLineDTO> orderLineList;
+
+		public static OrderDTO from(Order order) {
+			return OrderDTO.builder()
+				.orderId(order.getId())
+				.address(order.getAddress().getValue())
+				.requestInfo(order.getRequestInfo().getValue())
+				.orderTotalPrice(order.getOrderTotalPrice().getValue())
+				.orderLineList(OrderLineDTO.from(order.getOrderLineList()))
+				.build();
+		}
+
+		@Getter
+		@Builder
+		@NoArgsConstructor
+		@AllArgsConstructor
+		public static class OrderLineDTO {
+
+			private Long productId;
+			private int count;
+			private int supplyPrice;
+
+			public static List<OrderLineDTO> from(List<OrderLine> orderLineList) {
+				return orderLineList.stream()
+					.map(OrderLineDTO::from)
+					.toList();
+			}
+
+			public static OrderLineDTO from(OrderLine orderLine) {
+				return OrderLineDTO.builder()
+					.productId(orderLine.getProductId())
+					.count(orderLine.getCount().getValue())
+					.supplyPrice(orderLine.getSupplyPrice().getValue())
+					.build();
+			}
+		}
+	}
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResOrderSearchDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResOrderSearchDTO.java
@@ -1,0 +1,46 @@
+package com.first_class.msa.orders.application.dto;
+
+import org.springframework.data.domain.Page;
+
+import com.first_class.msa.orders.domain.model.Order;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResOrderSearchDTO {
+
+	private Page<OrderPage> orderPage;
+
+	public static ResOrderSearchDTO of(Page<ResOrderSearchDTO.OrderPage> orderPage) {
+		return ResOrderSearchDTO.builder()
+			.orderPage(orderPage)
+			.build();
+	}
+
+	@Getter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class OrderPage {
+
+		private Long orderId;
+		private String address;
+		private String requestInfo;
+		private Integer orderTotalPrice;
+
+		public static OrderPage from(Order order) {
+			return OrderPage.builder()
+				.orderId(order.getId())
+				.address(order.getAddress().getValue())
+				.requestInfo(order.getRequestInfo().getValue())
+				.orderTotalPrice(order.getOrderTotalPrice().getValue())
+				.build();
+		}
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResProductGetDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResProductGetDTO.java
@@ -1,0 +1,29 @@
+package com.first_class.msa.orders.application.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResProductGetDTO {
+
+	private Long productId;
+	private Integer count;
+	private Integer supplyPrice;
+	private Long hubId;
+
+	public static ResProductGetDTO from(Long productId, Integer count, Integer supplyPrice, Long hubId) {
+		return ResProductGetDTO.builder()
+			.productId(productId)
+			.count(count)
+			.supplyPrice(supplyPrice)
+			.hubId(hubId)
+			.build();
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResRoleGetByIdDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/dto/ResRoleGetByIdDTO.java
@@ -1,0 +1,8 @@
+package com.first_class.msa.orders.application.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ResRoleGetByIdDTO {
+	private String role;
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/AuthConditionService.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/AuthConditionService.java
@@ -1,0 +1,14 @@
+package com.first_class.msa.orders.application.service;
+
+import com.first_class.msa.orders.application.dto.AuthSearchConditionDTO;
+import com.first_class.msa.orders.domain.model.Order;
+import com.first_class.msa.orders.domain.model.UserRole;
+
+public interface AuthConditionService {
+
+	AuthSearchConditionDTO createSearchCondition(UserRole userRole, Long userId);
+
+	void validateOrderDetailAuth(UserRole userRole, Long userId, Order order);
+
+	void validateDeleteAuth(UserRole userRole, Long userId, Order order);
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/AuthConditionServiceImpl.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/AuthConditionServiceImpl.java
@@ -1,0 +1,103 @@
+package com.first_class.msa.orders.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.first_class.msa.orders.application.dto.AuthSearchConditionDTO;
+import com.first_class.msa.orders.application.dto.ResBusinessDTO;
+import com.first_class.msa.orders.application.dto.ResDeliveryOrderSearchDTO;
+import com.first_class.msa.orders.application.dto.ResDeliveryOrderSearchDetailDTO;
+import com.first_class.msa.orders.application.dto.ResHubDTO;
+import com.first_class.msa.orders.domain.model.Order;
+import com.first_class.msa.orders.domain.model.UserRole;
+import com.first_class.msa.orders.libs.exception.ApiException;
+import com.first_class.msa.orders.libs.message.ErrorMessage;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthConditionServiceImpl implements AuthConditionService{
+	private final HubService hubService;
+	private final BusinessService businessService;
+	private final DeliveryService deliveryService;
+
+	@Override
+	public AuthSearchConditionDTO createSearchCondition(UserRole userRole, Long userId) {
+		return switch (userRole) {
+			case MASTER -> AuthSearchConditionDTO.createForMaster();
+			case HUB_MANAGER -> {
+				Long hubId = getHubId(userId);
+				yield AuthSearchConditionDTO.createForHubManager(hubId);
+			}
+			case BUSINESS_MANAGER -> {
+				Long businessId = getBusinessId(userId);
+				yield AuthSearchConditionDTO.createForBusinessManager(businessId);
+			}
+			case DELIVERY_MANAGER -> {
+				List<Long> deliveryOrders = getDeliveryOrders(userId);
+				yield AuthSearchConditionDTO.createForDeliveryManager(deliveryOrders);
+			}
+		};
+	}
+
+	@Override
+	public void validateOrderDetailAuth(UserRole userRole, Long userId, Order order) {
+		switch (userRole) {
+			case HUB_MANAGER -> validateHubManager(userId, order);
+			case BUSINESS_MANAGER -> validateBusinessManager(userId, order);
+			case DELIVERY_MANAGER -> validateDeliveryManager(userId, order);
+			default -> throw new IllegalArgumentException(new ApiException(ErrorMessage.INVALID_USER_ROLE));
+		}
+	}
+
+	@Override
+	public void validateDeleteAuth(UserRole userRole, Long userId, Order order) {
+		if (UserRole.MASTER.equals(userRole)) {
+			return;
+		}
+
+		if (UserRole.HUB_MANAGER.equals(userRole)) {
+			validateHubManager(userId, order);
+		} else {
+			throw new IllegalArgumentException(new ApiException(ErrorMessage.INVALID_USER_ROLE));
+		}
+	}
+
+	private void validateHubManager(Long userId, Order order) {
+		Long hubId = getHubId(userId);
+		if (!order.getHubId().equals(hubId)) {
+			throw new IllegalArgumentException(new ApiException(ErrorMessage.INVALID_USER_ROLE_HUB_MANAGER));
+		}
+	}
+
+	private void validateBusinessManager(Long userId, Order order) {
+		Long businessId = getBusinessId(userId);
+		if (!order.getBusinessId().equals(businessId)) {
+			throw new IllegalArgumentException(new ApiException(ErrorMessage.INVALID_USER_ROLE_BUSINESS_MANAGER));
+		}
+	}
+
+	private void validateDeliveryManager(Long userId, Order order) {
+		ResDeliveryOrderSearchDetailDTO deliveryDetail = deliveryService.getDeliveryBy(userId, order.getId());
+		if (!deliveryDetail.getOrderId().equals(order.getId())) {
+			throw new IllegalArgumentException(new ApiException(ErrorMessage.INVALID_USER_ROLE_DELIVERY_MANAGER));
+		}
+	}
+
+	private Long getHubId(Long userId) {
+		ResHubDTO hubDTO = hubService.getHubBy(userId);
+		return hubDTO.getHubId();
+	}
+
+	private Long getBusinessId(Long userId) {
+		ResBusinessDTO businessDTO = businessService.getBusinessUserBy(userId);
+		return businessDTO.getBusinessId();
+	}
+
+	private List<Long> getDeliveryOrders(Long userId) {
+		ResDeliveryOrderSearchDTO deliveryOrders = deliveryService.getAllDeliveryBy(userId);
+		return deliveryOrders.getOrderIdList();
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/AuthService.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/AuthService.java
@@ -1,0 +1,10 @@
+package com.first_class.msa.orders.application.service;
+
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.first_class.msa.orders.application.dto.ResRoleGetByIdDTO;
+
+public interface AuthService {
+
+	ResRoleGetByIdDTO getRoleBy(@PathVariable Long userId);
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/BusinessService.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/BusinessService.java
@@ -1,0 +1,11 @@
+package com.first_class.msa.orders.application.service;
+
+import com.first_class.msa.orders.application.dto.ResBusinessDTO;
+
+public interface BusinessService {
+
+	ResBusinessDTO getBusinessBy(Long businessId);
+
+	ResBusinessDTO getBusinessUserBy(Long userId);
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/DeliveryService.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/DeliveryService.java
@@ -1,0 +1,10 @@
+package com.first_class.msa.orders.application.service;
+
+import com.first_class.msa.orders.application.dto.ResDeliveryOrderSearchDTO;
+import com.first_class.msa.orders.application.dto.ResDeliveryOrderSearchDetailDTO;
+
+public interface DeliveryService {
+	ResDeliveryOrderSearchDTO getAllDeliveryBy(Long userId);
+
+	ResDeliveryOrderSearchDetailDTO getDeliveryBy(Long orderId , Long userId);
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/HubService.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/HubService.java
@@ -1,0 +1,11 @@
+package com.first_class.msa.orders.application.service;
+
+import com.first_class.msa.orders.application.dto.ResHubDTO;
+
+public interface HubService {
+
+	ResHubDTO getHubBy(Long userId);
+
+
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/OrderEventService.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/OrderEventService.java
@@ -1,0 +1,16 @@
+package com.first_class.msa.orders.application.service;
+
+import java.util.List;
+
+import com.first_class.msa.orders.application.dto.ResOrderDTO;
+
+public interface OrderEventService {
+
+	void orderCreateProductEvent(Long orderId, List<ResOrderDTO.OrderDTO.OrderLineDTO> orderLineDTOList);
+
+	void orderCreateDeliveryEvent(Long orderId, String address);
+
+	void orderDeleteProductEvent(Long orderId, List<ResOrderDTO.OrderDTO.OrderLineDTO> orderLineDTOList);
+
+	void orderDeleteDeliveryEvent(Long orderId, Long userId);
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/OrderEventServiceImpl.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/OrderEventServiceImpl.java
@@ -1,0 +1,55 @@
+package com.first_class.msa.orders.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.first_class.msa.orders.application.dto.ResOrderDTO;
+import com.first_class.msa.orders.infrastructure.config.RabbitMQConfig;
+import com.first_class.msa.orders.infrastructure.event.OrderCreateDeliveryEvent;
+import com.first_class.msa.orders.infrastructure.event.OrderCreateProductEvent;
+import com.first_class.msa.orders.infrastructure.event.OrderDeleteDeliveryEvent;
+import com.first_class.msa.orders.infrastructure.event.OrderDeleteProductEvent;
+import com.first_class.msa.orders.infrastructure.messaging.OrderEventPublisher;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OrderEventServiceImpl implements OrderEventService{
+
+	private final OrderEventPublisher orderEventPublisher;
+
+	@Override
+	public void orderCreateProductEvent(
+		Long orderId,
+		List<ResOrderDTO.OrderDTO.OrderLineDTO> orderLineDTOList
+	) {
+		OrderCreateProductEvent orderCreateProductEvent = new OrderCreateProductEvent(orderId, orderLineDTOList);
+		orderEventPublisher.publishEvent(RabbitMQConfig.ORDER_CREATED_PRODUCT_KEY , orderCreateProductEvent);
+	}
+
+	@Override
+	public void orderCreateDeliveryEvent(
+		Long orderId,
+		String address
+	) {
+		OrderCreateDeliveryEvent orderCreateProductEvent = new OrderCreateDeliveryEvent(orderId, address);
+		orderEventPublisher.publishEvent(RabbitMQConfig.ORDER_CREATED_PRODUCT_KEY , orderCreateProductEvent);
+	}
+
+	@Override
+	public void orderDeleteProductEvent(
+		Long orderId,
+		List<ResOrderDTO.OrderDTO.OrderLineDTO> orderLineDTOList) {
+
+		OrderDeleteProductEvent orderDeleteProductEvent = new OrderDeleteProductEvent(orderId, orderLineDTOList);
+		orderEventPublisher.publishEvent(RabbitMQConfig.ORDER_DELETED_PRODUCT_KEY , orderDeleteProductEvent);
+	}
+
+	@Override
+	public void orderDeleteDeliveryEvent(Long orderId, Long userId) {
+		OrderDeleteDeliveryEvent orderDeleteDeliveryEvent = new OrderDeleteDeliveryEvent(orderId, userId);
+		orderEventPublisher.publishEvent(RabbitMQConfig.ORDER_DELETED_DELIVERY_KEY, orderDeleteDeliveryEvent);
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/OrderLineService.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/OrderLineService.java
@@ -1,0 +1,15 @@
+package com.first_class.msa.orders.application.service;
+
+import java.util.List;
+
+import com.first_class.msa.orders.domain.model.Order;
+import com.first_class.msa.orders.domain.model.OrderLine;
+import com.first_class.msa.orders.presentation.request.ReqOrderPostDTO;
+
+public interface OrderLineService {
+
+	List<OrderLine> createOrderLineList(List<ReqOrderPostDTO.ReqOrderLinePostDTO> orderLinePostDTOList, Order order);
+
+
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/OrderLineServiceImpl.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/OrderLineServiceImpl.java
@@ -1,0 +1,55 @@
+package com.first_class.msa.orders.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.first_class.msa.orders.application.dto.ResProductGetDTO;
+import com.first_class.msa.orders.domain.model.Order;
+import com.first_class.msa.orders.domain.model.OrderLine;
+import com.first_class.msa.orders.domain.model.valueobject.Count;
+import com.first_class.msa.orders.domain.model.valueobject.SupplyPrice;
+import com.first_class.msa.orders.libs.exception.ApiException;
+import com.first_class.msa.orders.libs.message.ErrorMessage;
+import com.first_class.msa.orders.presentation.request.ReqOrderPostDTO;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OrderLineServiceImpl implements OrderLineService {
+
+	private final ProductService productService;
+
+	@Override
+	@Transactional
+	public List<OrderLine> createOrderLineList(
+		List<ReqOrderPostDTO.ReqOrderLinePostDTO> orderLinePostDTOList,
+		Order order
+	) {
+		List<Long> productIdList
+			= orderLinePostDTOList.stream()
+			.map(ReqOrderPostDTO.ReqOrderLinePostDTO::getProductId)
+			.toList();
+
+		List<ResProductGetDTO> resProductListDTO = productService.getAllProductBy(productIdList);
+		return resProductListDTO.stream()
+			.map(resProductDto -> {
+				ReqOrderPostDTO.ReqOrderLinePostDTO matchingRequest = orderLinePostDTOList.stream()
+					.filter(reqOrderLineDTO -> reqOrderLineDTO.getProductId().equals(resProductDto.getProductId()))
+					.findFirst()
+					.orElseThrow(() -> new IllegalArgumentException(new ApiException(ErrorMessage.NOT_FOUND_PRODUCT)));
+
+				if (resProductDto.getCount() < matchingRequest.getCount()) {
+					throw new IllegalArgumentException(new ApiException(ErrorMessage.INSUFFICIENT_COUNT));
+				}
+
+				Count count = new Count(matchingRequest.getCount());
+				SupplyPrice supplyPrice = new SupplyPrice(matchingRequest.getSupplyPrice());
+				return OrderLine.createOrderLine(order, resProductDto.getProductId(), count, supplyPrice);
+			})
+			.toList();
+	}
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/OrderService.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/OrderService.java
@@ -1,0 +1,21 @@
+package com.first_class.msa.orders.application.service;
+
+import org.springframework.data.domain.Pageable;
+
+import com.first_class.msa.orders.application.dto.ResOrderDTO;
+import com.first_class.msa.orders.application.dto.ResOrderSearchDTO;
+import com.first_class.msa.orders.presentation.request.ReqOrderPostDTO;
+
+public interface OrderService {
+
+	ResOrderDTO postBy(Long businessId, Long userId, ReqOrderPostDTO reqOrderPostDTO);
+
+	ResOrderSearchDTO getAllOrderBy(Long userId, Pageable pageable);
+
+	ResOrderDTO getOrderDetailBy(Long userId, Long orderId);
+
+	void deleteBy(Long userId, Long orderId);
+
+
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/OrderServiceImpl.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/OrderServiceImpl.java
@@ -1,0 +1,103 @@
+package com.first_class.msa.orders.application.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.first_class.msa.orders.application.dto.AuthSearchConditionDTO;
+import com.first_class.msa.orders.application.dto.ResBusinessDTO;
+import com.first_class.msa.orders.application.dto.ResOrderDTO;
+import com.first_class.msa.orders.application.dto.ResOrderSearchDTO;
+import com.first_class.msa.orders.domain.model.Order;
+import com.first_class.msa.orders.domain.model.OrderLine;
+import com.first_class.msa.orders.domain.model.UserRole;
+import com.first_class.msa.orders.domain.model.valueobject.Address;
+import com.first_class.msa.orders.domain.model.valueobject.RequestInfo;
+import com.first_class.msa.orders.domain.repository.OrderRepository;
+import com.first_class.msa.orders.libs.exception.ApiException;
+import com.first_class.msa.orders.libs.message.ErrorMessage;
+import com.first_class.msa.orders.presentation.request.ReqOrderPostDTO;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OrderServiceImpl implements OrderService {
+	private final OrderRepository orderRepository;
+	private final OrderLineService orderLineService;
+	private final OrderEventService orderEventService;
+	private final AuthService authService;
+	private final BusinessService businessService;
+	private final AuthConditionService authConditionService; // 추가된 의존성
+
+	@Override
+	@Transactional
+	public ResOrderDTO postBy(Long businessId, Long userId, ReqOrderPostDTO reqOrderPostDTO) {
+		Address address = new Address(reqOrderPostDTO.getAddress());
+		RequestInfo requestInfo = new RequestInfo(reqOrderPostDTO.getRequestInfo());
+		ResBusinessDTO resBusinessDTO = businessService.getBusinessBy(businessId);
+
+		Order order = Order.createOrder(businessId, resBusinessDTO.getHubId(), userId, address, requestInfo);
+		order.setCreateByAndUpdateBy(userId);
+
+		List<OrderLine> orderLineList = orderLineService.createOrderLineList(
+			reqOrderPostDTO.getReqOrderLinePostDTOList(), order);
+
+		order.addOrderLineList(orderLineList);
+		order.updateOrderTotalPrice(orderLineList);
+		order = orderRepository.save(order);
+
+		ResOrderDTO orderPostDTO = ResOrderDTO.of(order);
+		orderEventService.orderCreateProductEvent(order.getId(), orderPostDTO.getOrderDTO().getOrderLineList());
+		orderEventService.orderCreateDeliveryEvent(order.getId(), order.getAddress().getValue());
+
+		return orderPostDTO;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public ResOrderSearchDTO getAllOrderBy(Long userId, Pageable pageable) {
+		String userRole = authService.getRoleBy(userId).getRole();
+		AuthSearchConditionDTO searchCondition
+			= authConditionService.createSearchCondition(UserRole.valueOf(userRole), userId);
+		return orderRepository.findAll(searchCondition, pageable);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public ResOrderDTO getOrderDetailBy(Long userId, Long orderId) {
+		String userRole = authService.getRoleBy(userId).getRole();
+		Order order = findById(orderId);
+
+		authConditionService.validateOrderDetailAuth(UserRole.valueOf(userRole), userId, order);
+
+		return ResOrderDTO.of(order);
+	}
+
+	@Override
+	@Transactional
+	public void deleteBy(Long userId, Long orderId) {
+		String userRole = authService.getRoleBy(userId).getRole();
+		Order order = findById(orderId);
+
+		authConditionService.validateDeleteAuth(UserRole.valueOf(userRole), userId, order);
+
+		order.deleteOrder(userId);
+
+		orderEventService.orderDeleteProductEvent(
+			order.getId(),
+			ResOrderDTO.OrderDTO.OrderLineDTO.from(order.getOrderLineList())
+		);
+		orderEventService.orderDeleteDeliveryEvent(order.getId(), userId);
+	}
+
+	private Order findById(Long orderId) {
+		return orderRepository.findById(orderId)
+			.orElseThrow(() -> new IllegalArgumentException(new ApiException(ErrorMessage.NOT_FOUND_ORDER)));
+	}
+
+	// TODO: 2024-12-12 배송 주소 변경관련 메세지큐 처리 
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/ProductService.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/application/service/ProductService.java
@@ -1,0 +1,10 @@
+package com.first_class.msa.orders.application.service;
+
+import java.util.List;
+
+import com.first_class.msa.orders.application.dto.ResProductGetDTO;
+
+public interface ProductService {
+
+	List<ResProductGetDTO> getAllProductBy(List<Long> productIdList);
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/Order.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/Order.java
@@ -1,0 +1,104 @@
+package com.first_class.msa.orders.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.first_class.msa.orders.domain.model.common.BaseTime;
+import com.first_class.msa.orders.domain.model.valueobject.Address;
+import com.first_class.msa.orders.domain.model.valueobject.OrderTotalPrice;
+import com.first_class.msa.orders.domain.model.valueobject.RequestInfo;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_orders")
+public class Order extends BaseTime {
+
+	@Id
+	@Tsid
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "business_id", nullable = false)
+	private Long businessId;
+
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Column(name = "hub_id", nullable = false)
+	private Long hubId;
+
+	@Embedded
+	@Column(name = "address", nullable = false)
+	private Address address;
+
+	@Embedded
+	@Column(name = "request_info", nullable = false)
+	private RequestInfo requestInfo;
+
+	@Embedded
+	@Column(name = "order_total_price", nullable = false)
+	private OrderTotalPrice orderTotalPrice;
+
+	@OneToMany(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	private List<OrderLine> orderLineList = new ArrayList<>();
+
+	public static Order createOrder(Long businessId, Long hubId, Long userId, Address address,RequestInfo requestInfo) {
+		return Order.builder()
+			.businessId(businessId)
+			.hubId(hubId)
+			.userId(userId)
+			.address(address)
+			.requestInfo(requestInfo)
+			.build();
+
+	}
+
+	public void setCreateByAndUpdateBy(Long userId){
+		this.setCreatedBy(userId);
+		this.setUpdatedBy(userId);
+	}
+
+	public void addOrderLineList(List<OrderLine> orderLineList) {
+		this.orderLineList = orderLineList;
+	}
+
+	public void updateOrderTotalPrice(List<OrderLine> orderLineList) {
+		this.orderTotalPrice =
+			new OrderTotalPrice(
+				orderLineList.stream()
+					.mapToInt(orderLine -> orderLine.getCount().getValue() * orderLine.getSupplyPrice().getValue())
+					.sum()
+			);
+	}
+
+	public void deleteOrder(Long userId){
+		this.setDeletedAt(LocalDateTime.now());
+		this.setDeletedBy(userId);
+
+		for (OrderLine orderLine: orderLineList) {
+			orderLine.deleteOrderLine(userId);
+		}
+	}
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/OrderLine.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/OrderLine.java
@@ -1,0 +1,64 @@
+package com.first_class.msa.orders.domain.model;
+
+import java.time.LocalDateTime;
+
+import com.first_class.msa.orders.domain.model.common.BaseTime;
+import com.first_class.msa.orders.domain.model.valueobject.Count;
+import com.first_class.msa.orders.domain.model.valueobject.SupplyPrice;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_order_lines")
+public class OrderLine extends BaseTime {
+	@Id
+	@Tsid
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id", nullable = false)
+	private Order order;
+
+	@Column(name = "product_id", nullable = false)
+	private Long productId;
+
+	@Embedded
+	private Count count;
+
+	@Embedded
+	private SupplyPrice supplyPrice;
+
+	public static OrderLine createOrderLine(Order order, Long productId, Count count, SupplyPrice supplyPrice) {
+		return OrderLine.builder()
+			.order(order)
+			.productId(productId)
+			.count(count)
+			.supplyPrice(supplyPrice)
+			.build();
+	}
+
+	public void deleteOrderLine(Long userId){
+		this.setDeletedAt(LocalDateTime.now());
+		this.setDeletedBy(userId);
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/UserRole.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/UserRole.java
@@ -1,0 +1,8 @@
+package com.first_class.msa.orders.domain.model;
+
+public enum UserRole {
+	MASTER,
+	HUB_MANAGER,
+	BUSINESS_MANAGER,
+	DELIVERY_MANAGER
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/common/BaseTime.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/common/BaseTime.java
@@ -1,0 +1,46 @@
+package com.first_class.msa.orders.domain.model.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTime {
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Setter
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Setter
+	@CreatedBy
+	@Column(name = "created_by", updatable = false)
+	private Long createdBy;
+
+	@Setter
+	@LastModifiedBy
+	@Column(name = "updated_by")
+	private Long updatedBy;
+
+	@Setter
+	@Column(name = "deleted_by")
+	private Long deletedBy;
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/valueobject/Address.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/valueobject/Address.java
@@ -1,0 +1,32 @@
+package com.first_class.msa.orders.domain.model.valueobject;
+
+import com.first_class.msa.orders.libs.exception.ApiException;
+import com.first_class.msa.orders.libs.message.ErrorMessage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address {
+	@Column(name = "address", nullable = false)
+	String value;
+
+	public Address(String value){
+		if(value == null || value.trim().isEmpty()){
+			throw new IllegalArgumentException(new ApiException(ErrorMessage.REQUEST_INFO_REQUEST_EMPTY));
+		}
+		this.value = value;
+	}
+	@Override
+	public String toString(){
+		return value;
+	}
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/valueobject/Count.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/valueobject/Count.java
@@ -1,0 +1,31 @@
+package com.first_class.msa.orders.domain.model.valueobject;
+
+import com.first_class.msa.orders.libs.exception.ApiException;
+import com.first_class.msa.orders.libs.message.ErrorMessage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Count {
+	@Column(name = "count", nullable = false)
+	Integer value;
+
+	public Count(Integer value){
+		if(value == null){
+			throw new IllegalArgumentException(new ApiException(ErrorMessage.PRODUCT_COUNT_EMPTY));
+		}
+		if(value < 0){
+			throw new IllegalArgumentException(new ApiException(ErrorMessage.PRODUCT_COUNT_NOT_MINUS));
+		}
+		this.value = value;
+
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/valueobject/OrderTotalPrice.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/valueobject/OrderTotalPrice.java
@@ -1,0 +1,32 @@
+package com.first_class.msa.orders.domain.model.valueobject;
+
+import com.first_class.msa.orders.libs.exception.ApiException;
+import com.first_class.msa.orders.libs.message.ErrorMessage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderTotalPrice {
+
+	@Column(name = "order_total_price", nullable = false)
+	Integer value;
+
+	public OrderTotalPrice(Integer value){
+		if(value == null){
+			throw new IllegalArgumentException(new ApiException(ErrorMessage.ORDER_TOTAL_PRICE_EMPTY));
+		}
+		if(value < 0){
+			throw new IllegalArgumentException(new ApiException(ErrorMessage.ORDER_TOTAL_PRICE_NOT_MINUS));
+		}
+		this.value = value;
+
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/valueobject/RequestInfo.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/valueobject/RequestInfo.java
@@ -1,0 +1,31 @@
+package com.first_class.msa.orders.domain.model.valueobject;
+
+import com.first_class.msa.orders.libs.exception.ApiException;
+import com.first_class.msa.orders.libs.message.ErrorMessage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RequestInfo {
+	@Column(name = "request_info", nullable = false)
+	String value;
+
+	public RequestInfo(String value){
+		if(value == null || value.trim().isEmpty()){
+			throw new IllegalArgumentException(new ApiException(ErrorMessage.REQUEST_INFO_REQUEST_EMPTY));
+		}
+		this.value = value;
+	}
+	@Override
+	public String toString(){
+		return value;
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/valueobject/SupplyPrice.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/model/valueobject/SupplyPrice.java
@@ -1,0 +1,30 @@
+package com.first_class.msa.orders.domain.model.valueobject;
+
+import com.first_class.msa.orders.libs.exception.ApiException;
+import com.first_class.msa.orders.libs.message.ErrorMessage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SupplyPrice {
+	@Column(name = "supply_price", nullable = false)
+	Integer value;
+
+	public SupplyPrice(Integer value){
+		if(value == null){
+			throw new IllegalArgumentException(new ApiException(ErrorMessage.REQUEST_INFO_REQUEST_EMPTY));
+		}
+		if(value < 0){
+			throw new IllegalArgumentException(new ApiException(ErrorMessage.REQUEST_INFO_REQUEST_EMPTY));
+		}
+		this.value = value;
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/repository/OrderRepository.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/domain/repository/OrderRepository.java
@@ -1,0 +1,20 @@
+package com.first_class.msa.orders.domain.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.first_class.msa.orders.application.dto.AuthSearchConditionDTO;
+import com.first_class.msa.orders.application.dto.ResOrderSearchDTO;
+import com.first_class.msa.orders.domain.model.Order;
+
+@Repository
+public interface OrderRepository {
+
+	Order save(Order order);
+
+	ResOrderSearchDTO findAll(AuthSearchConditionDTO authSearchConditionDTO, Pageable pageable);
+
+	Optional<Order> findById(Long orderId);
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/client/AuthClient.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/client/AuthClient.java
@@ -1,0 +1,13 @@
+package com.first_class.msa.orders.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.first_class.msa.orders.application.dto.ResRoleGetByIdDTO;
+import com.first_class.msa.orders.application.service.AuthService;
+@FeignClient(name = "auth-service")
+public interface AuthClient extends AuthService {
+	@GetMapping("/auth/{userId}")
+	ResRoleGetByIdDTO getRoleBy(@PathVariable(name = "userId") Long userId);
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/client/BusinessClient.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/client/BusinessClient.java
@@ -1,0 +1,17 @@
+package com.first_class.msa.orders.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.first_class.msa.orders.application.dto.ResBusinessDTO;
+import com.first_class.msa.orders.application.service.BusinessService;
+@FeignClient(name = "business-service")
+public interface BusinessClient extends BusinessService {
+
+	@GetMapping({"/business/{businessId}"})
+	ResBusinessDTO getBusinessBy(@PathVariable(name = "businessId") Long businessId);
+
+	@GetMapping({"/business/{userId}"})
+	ResBusinessDTO getBusinessUserBy(@PathVariable Long userId);
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/client/DeliveryClient.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/client/DeliveryClient.java
@@ -1,0 +1,25 @@
+package com.first_class.msa.orders.infrastructure.client;
+
+import java.util.List;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.first_class.msa.orders.application.dto.ResDeliveryOrderSearchDTO;
+import com.first_class.msa.orders.application.dto.ResDeliveryOrderSearchDetailDTO;
+import com.first_class.msa.orders.application.service.DeliveryService;
+
+@FeignClient(name = "delivery-service")
+public interface DeliveryClient extends DeliveryService {
+
+	@GetMapping("/orders/deliveries")
+	ResDeliveryOrderSearchDTO getAllDeliveryBy(@RequestParam List<Long> orderIdList);
+
+	@GetMapping("/orders/{orderId}/deliveries/}")
+	ResDeliveryOrderSearchDetailDTO getDeliveryBy(@PathVariable Long orderId, @RequestParam Long userId);
+
+
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/client/HubClient.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/client/HubClient.java
@@ -1,0 +1,16 @@
+package com.first_class.msa.orders.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.first_class.msa.orders.application.dto.ResHubDTO;
+import com.first_class.msa.orders.application.service.HubService;
+
+@FeignClient(name = "hub-service")
+public interface HubClient extends HubService {
+
+	@GetMapping("/hubs/{userId}")
+	ResHubDTO getHubBy(@PathVariable(name = "userId") Long userId);
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/client/ProductClient.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/client/ProductClient.java
@@ -1,0 +1,17 @@
+package com.first_class.msa.orders.infrastructure.client;
+
+import java.util.List;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.first_class.msa.orders.application.dto.ResProductGetDTO;
+import com.first_class.msa.orders.application.service.ProductService;
+
+@FeignClient(name = "product-service")
+public interface ProductClient extends ProductService {
+
+	@GetMapping("/products")
+	List<ResProductGetDTO> getAllProductBy(@RequestParam List<Long> productIdList);
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/config/QuerydslConfig.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/config/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package com.first_class.msa.orders.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory queryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/config/RabbitMQConfig.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/config/RabbitMQConfig.java
@@ -1,0 +1,78 @@
+package com.first_class.msa.orders.infrastructure.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+	public static final String EXCHANGE_NAME = "order.exchange";
+	public static final String PRODUCT_QUEUE = "product.queue";
+	public static final String DELIVERY_QUEUE = "delivery.queue";
+
+	// 라우팅 키
+	public static final String ORDER_CREATED_PRODUCT_KEY = "order.created.product";
+
+	public static final String ORDER_DELETED_PRODUCT_KEY = "order.deleted.product";
+
+	public static final String ORDER_CREATED_DELIVERY_KEY = "order.created.delivery";
+
+	public static final String ORDER_DELETED_DELIVERY_KEY = "order.deleted.delivery";
+
+	@Bean
+	public TopicExchange exchange() {
+		return new TopicExchange(EXCHANGE_NAME);
+	}
+
+	@Bean
+	public Queue productQueue() {
+		return new Queue(PRODUCT_QUEUE, true);
+	}
+
+	@Bean
+	public Queue deliveryQueue() {
+		return new Queue(DELIVERY_QUEUE, true);
+	}
+
+	@Bean
+	public Jackson2JsonMessageConverter jsonMessageConverter() {
+		return new Jackson2JsonMessageConverter();
+	}
+
+	@Bean
+	public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+		RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+		rabbitTemplate.setMessageConverter(jsonMessageConverter());
+		return rabbitTemplate;
+	}
+
+	// Binding: product.queue
+	@Bean
+	public Binding productCreatedBinding(Queue productQueue, TopicExchange exchange) {
+		return BindingBuilder.bind(productQueue).to(exchange).with(ORDER_CREATED_PRODUCT_KEY);
+	}
+
+	@Bean
+	public Binding productDeletedBinding(Queue productQueue, TopicExchange exchange) {
+		return BindingBuilder.bind(productQueue).to(exchange).with(ORDER_DELETED_PRODUCT_KEY);
+	}
+
+	// Binding: delivery.queue
+	@Bean
+	public Binding deliveryCreatedBinding(Queue deliveryQueue, TopicExchange exchange) {
+		return BindingBuilder.bind(deliveryQueue).to(exchange).with(ORDER_CREATED_DELIVERY_KEY);
+	}
+
+	@Bean
+	public Binding deliveryDeletedBinding(Queue deliveryQueue, TopicExchange exchange) {
+		return BindingBuilder.bind(deliveryQueue).to(exchange).with(ORDER_DELETED_DELIVERY_KEY);
+	}
+
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/event/OrderCreateDeliveryEvent.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/event/OrderCreateDeliveryEvent.java
@@ -1,0 +1,13 @@
+package com.first_class.msa.orders.infrastructure.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderCreateDeliveryEvent {
+	private Long orderId;
+	private String address;
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/event/OrderCreateProductEvent.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/event/OrderCreateProductEvent.java
@@ -1,0 +1,19 @@
+package com.first_class.msa.orders.infrastructure.event;
+
+import java.util.List;
+
+import com.first_class.msa.orders.application.dto.ResOrderDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderCreateProductEvent {
+	private Long orderId;
+	private List<ResOrderDTO.OrderDTO.OrderLineDTO> orderLineDTO;
+
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/event/OrderDeleteDeliveryEvent.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/event/OrderDeleteDeliveryEvent.java
@@ -1,0 +1,13 @@
+package com.first_class.msa.orders.infrastructure.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderDeleteDeliveryEvent {
+	private Long orderId;
+	private Long userId;
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/event/OrderDeleteProductEvent.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/event/OrderDeleteProductEvent.java
@@ -1,0 +1,17 @@
+package com.first_class.msa.orders.infrastructure.event;
+
+import java.util.List;
+
+import com.first_class.msa.orders.application.dto.ResOrderDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderDeleteProductEvent {
+	private Long orderId;
+	private List<ResOrderDTO.OrderDTO.OrderLineDTO> orderLineDTO;
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/messaging/OrderEventPublisher.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/messaging/OrderEventPublisher.java
@@ -1,0 +1,25 @@
+package com.first_class.msa.orders.infrastructure.messaging;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+import com.first_class.msa.orders.infrastructure.config.RabbitMQConfig;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderEventPublisher {
+	private final RabbitTemplate rabbitTemplate;
+
+	public void publishEvent(String routingKey, Object message) {
+		rabbitTemplate.convertAndSend(
+			RabbitMQConfig.EXCHANGE_NAME,
+			routingKey,
+			message
+		);
+		log.info("이벤트 메세지 발생 key {}, message {}", routingKey, message);
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/repository/OrderJpaRepository.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/repository/OrderJpaRepository.java
@@ -1,0 +1,8 @@
+package com.first_class.msa.orders.infrastructure.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.first_class.msa.orders.domain.model.Order;
+
+public interface OrderJpaRepository extends JpaRepository<Order, Long>{
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/repository/OrderQueryRepository.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/repository/OrderQueryRepository.java
@@ -1,0 +1,12 @@
+package com.first_class.msa.orders.infrastructure.repository;
+
+import org.springframework.data.domain.Pageable;
+
+import com.first_class.msa.orders.application.dto.ResOrderSearchDTO;
+import com.first_class.msa.orders.application.dto.AuthSearchConditionDTO;
+
+public interface OrderQueryRepository {
+
+	ResOrderSearchDTO findAll(AuthSearchConditionDTO authSearchConditionDTO, Pageable pageable);
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/repository/OrderQueryRepositoryImpl.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/repository/OrderQueryRepositoryImpl.java
@@ -1,0 +1,98 @@
+package com.first_class.msa.orders.infrastructure.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.first_class.msa.orders.application.dto.ResOrderSearchDTO;
+import com.first_class.msa.orders.application.dto.AuthSearchConditionDTO;
+import com.first_class.msa.orders.domain.model.QOrder;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderQueryRepositoryImpl implements OrderQueryRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	QOrder qOrder = QOrder.order;
+
+	@Override
+	public ResOrderSearchDTO findAll(AuthSearchConditionDTO authSearchConditionDTO, Pageable pageable) {
+
+		List<ResOrderSearchDTO.OrderPage> results = jpaQueryFactory
+			.select(Projections.constructor(
+				ResOrderSearchDTO.OrderPage.class,
+				qOrder.id,
+				qOrder.address,
+				qOrder.requestInfo.value,
+				qOrder.orderTotalPrice.value
+			))
+			.from(qOrder)
+			.where(buildDynamicConditions(authSearchConditionDTO))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		long total = Optional.ofNullable(
+			jpaQueryFactory
+				.select(qOrder.count())
+				.from(qOrder)
+				.where(buildDynamicConditions(authSearchConditionDTO))
+				.fetchOne()
+		).orElse(0L);
+
+		Page<ResOrderSearchDTO.OrderPage> page = new PageImpl<>(results, pageable, total);
+		return ResOrderSearchDTO.of(page);
+	}
+
+	private BooleanBuilder buildDynamicConditions(AuthSearchConditionDTO authSearchConditionDTO) {
+		BooleanBuilder builder = new BooleanBuilder();
+
+		// 권한에 따른 조건 추가
+		switch (authSearchConditionDTO.getUserRole()) {
+			case "MASTER":
+				break;
+			case "HUB_MANAGER":
+				builder.and(hubIdEquals(authSearchConditionDTO.getHubId()));
+				break;
+			case "BUSINESS_MANAGER":
+				builder.and(businessIdEquals(authSearchConditionDTO.getBusinessId()));
+				break;
+			case "DELIVERY_MANAGER":
+				builder.and(deliveryOrderEquals(authSearchConditionDTO.getOrderIdList()));
+				break;
+			default:
+				Object o = null;
+				break;
+		}
+
+		return builder;
+	}
+
+	private BooleanExpression deliveryOrderEquals(List<Long> orderIdList){
+		return orderIdList != null ? qOrder.id.in(orderIdList) : null;
+	}
+
+	private BooleanExpression userIdEquals(Long userId) {
+		return userId != null ? qOrder.userId.eq(userId): null;
+	}
+
+	private BooleanExpression businessIdEquals(Long businessId) {
+		return businessId != null ? qOrder.businessId.eq(businessId) : null;
+	}
+
+	private BooleanExpression hubIdEquals(Long hubId) {
+		return hubId != null ? qOrder.hubId.eq(hubId) : null;
+	}
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/repository/OrderRepositoryImpl.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/infrastructure/repository/OrderRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.first_class.msa.orders.infrastructure.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.first_class.msa.orders.application.dto.AuthSearchConditionDTO;
+import com.first_class.msa.orders.application.dto.ResOrderSearchDTO;
+import com.first_class.msa.orders.domain.model.Order;
+import com.first_class.msa.orders.domain.repository.OrderRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepository {
+	private final OrderJpaRepository orderJpaRepository;
+	private final OrderQueryRepository orderQueryRepository;
+
+	@Override
+	public Order save(Order order) {
+		return orderJpaRepository.save(order);
+	}
+
+	@Override
+	public ResOrderSearchDTO findAll(AuthSearchConditionDTO authSearchConditionDTO, Pageable pageable) {
+		return orderQueryRepository.findAll(authSearchConditionDTO, pageable);
+	}
+
+	@Override
+	public Optional<Order> findById(Long orderId) {
+		return orderJpaRepository.findById(orderId);
+	}
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/libs/dto/ExceptionResponseDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/libs/dto/ExceptionResponseDTO.java
@@ -1,0 +1,19 @@
+package com.first_class.msa.orders.libs.dto;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ExceptionResponseDTO<T> {
+
+	private final HttpStatus status;
+	private final String msg;
+	private final T data;
+
+	public static <T> ExceptionResponseDTO<T> of(HttpStatus status, String msg, T data) {
+		return new ExceptionResponseDTO<>(status, msg, data);
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/libs/dto/SuccessResponseDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/libs/dto/SuccessResponseDTO.java
@@ -1,0 +1,16 @@
+package com.first_class.msa.orders.libs.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SuccessResponseDTO<T> {
+	private Integer code;
+	private String message;
+	private T data;
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/libs/exception/ApiException.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/libs/exception/ApiException.java
@@ -1,0 +1,18 @@
+package com.first_class.msa.orders.libs.exception;
+
+import com.first_class.msa.orders.libs.message.ErrorMessage;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ApiException extends RuntimeException{
+
+	private final ErrorMessage errorMessage;
+	private final String message;
+	public ApiException(ErrorMessage error){
+		this.errorMessage = error;
+		this.message = error.getMessage();
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/libs/exception/GlobalExceptionHandler.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/libs/exception/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.first_class.msa.orders.libs.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.first_class.msa.orders.libs.dto.ExceptionResponseDTO;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<ExceptionResponseDTO<Void>> handleRuntimeException(RuntimeException e) {
+		log.error("RuntimeException: ", e);
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(ExceptionResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러", null));
+	}
+
+	@ExceptionHandler(ApiException.class)
+	public ResponseEntity<ExceptionResponseDTO<Void>> customExceptionHandler(ApiException e) {
+		log.error("CustomException: "+ e);
+		return ResponseEntity.status(e.getErrorMessage().getHttpStatus()).body(
+			ExceptionResponseDTO.of(
+				e.getErrorMessage().getHttpStatus(),
+				e.getErrorMessage().getMessage(),
+				null
+			)
+		);
+	}
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/libs/message/ErrorMessage.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/libs/message/ErrorMessage.java
@@ -1,0 +1,44 @@
+package com.first_class.msa.orders.libs.message;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorMessage {
+
+	/**
+	 * User
+	 */
+	INVALID_USER_ROLE(HttpStatus.FORBIDDEN, "해당 유저는 접근이 불가한 서비스입니다."),
+	INVALID_USER_ROLE_HUB_MANAGER(HttpStatus.FORBIDDEN, "허브 매니저 권한 인증에 실패했습니다."),
+	INVALID_USER_ROLE_BUSINESS_MANAGER(HttpStatus.FORBIDDEN, "업체 매니저 권한 인증에 실패했습니다."),
+	INVALID_USER_ROLE_DELIVERY_MANAGER(HttpStatus.FORBIDDEN, "배송 매니저 권한 인증에 실패했습니다."),
+
+	/**
+	 * Order
+	 */
+	NOT_FOUND_ORDER(HttpStatus.BAD_REQUEST, "해당하는 주문을 찾을 수 없습니다."),
+	REQUEST_INFO_REQUEST_EMPTY(HttpStatus.BAD_REQUEST, "요청사항은 필수입니다."),
+	ORDER_TOTAL_PRICE_NOT_MINUS(HttpStatus.BAD_REQUEST, "수량은 음수일 수 없습니다."),
+	ORDER_TOTAL_PRICE_EMPTY(HttpStatus.BAD_REQUEST, "총 가격이 비어있습니다."),
+	INSUFFICIENT_COUNT(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
+	/**
+	 * Product
+	 */
+	NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
+	/**
+	 * OrderLine
+	 */
+	SUPPLY_PRICE_NOT_MINUS(HttpStatus.BAD_REQUEST, "수량은 음수일 수 없습니다."),
+	SUPPLY_PRICE_EMPTY(HttpStatus.BAD_REQUEST, "총 가격이 비어있습니다."),
+	PRODUCT_COUNT_EMPTY(HttpStatus.BAD_REQUEST, "수량이 비어있습니다."),
+	PRODUCT_COUNT_NOT_MINUS(HttpStatus.BAD_REQUEST, "수량은 음수일 수 없습니다.");
+
+
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/presentation/controller/OrderController.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/presentation/controller/OrderController.java
@@ -1,0 +1,75 @@
+package com.first_class.msa.orders.presentation.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.first_class.msa.orders.application.dto.ResDTO;
+import com.first_class.msa.orders.application.dto.ResOrderDTO;
+import com.first_class.msa.orders.application.dto.ResOrderSearchDTO;
+import com.first_class.msa.orders.application.service.OrderService;
+import com.first_class.msa.orders.presentation.request.ReqOrderPostDTO;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/orders")
+public class OrderController {
+	private final OrderService orderService;
+
+	@PostMapping("/{businessId}")
+	public ResponseEntity<ResDTO<ResOrderDTO>> postBy(
+		@PathVariable Long businessId,
+		@RequestHeader("X-User-Id") Long userId,
+		@RequestBody ReqOrderPostDTO reqOrderPostDTO)
+	{
+		return new ResponseEntity<>(
+			ResDTO.<ResOrderDTO>builder()
+				.code(HttpStatus.CREATED.value())
+				.message("주문 생성 성공")
+				.data(orderService.postBy(businessId, userId, reqOrderPostDTO))
+				.build(),
+			HttpStatus.CREATED
+		);
+
+	}
+
+	@GetMapping
+	public ResponseEntity<ResDTO<ResOrderSearchDTO>> getAllOrderBy(
+		@RequestHeader("X-User-Id") Long userId,
+		Pageable pageable
+	){
+		return new ResponseEntity<>(
+			ResDTO.<ResOrderSearchDTO>builder()
+				.code(HttpStatus.OK.value())
+				.message("주문 조회 성공")
+				.data(orderService.getAllOrderBy(userId, pageable))
+				.build(),
+			HttpStatus.OK
+		);
+	}
+
+	@GetMapping("/{orderId}")
+	public ResponseEntity<ResDTO<ResOrderDTO>> getOrderDetailBy(
+		@RequestHeader("X-User-Id") Long userId,
+		@PathVariable Long orderId
+	){
+		return new ResponseEntity<>(
+			ResDTO.<ResOrderDTO>builder()
+				.code(HttpStatus.OK.value())
+				.data(orderService.getOrderDetailBy(userId ,orderId))
+				.build(),
+			HttpStatus.OK
+		);
+	}
+
+
+}

--- a/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/presentation/request/ReqOrderPostDTO.java
+++ b/com.first-class.msa.orders/src/main/java/com/first_class/msa/orders/presentation/request/ReqOrderPostDTO.java
@@ -1,0 +1,19 @@
+package com.first_class.msa.orders.presentation.request;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class ReqOrderPostDTO {
+	private String requestInfo;
+	private String address;
+	private List<ReqOrderLinePostDTO> reqOrderLinePostDTOList;
+
+	@Getter
+	public static class ReqOrderLinePostDTO{
+		private Long productId;
+		private int count;
+		private int supplyPrice;
+	}
+}

--- a/com.first-class.msa.orders/src/main/resources/application.yml
+++ b/com.first-class.msa.orders/src/main/resources/application.yml
@@ -18,10 +18,21 @@ spring:
         format_sql: true
     open-in-view: false
 
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
+    listener:
+      simple:
+        auto-startup: false
+
+
+
 eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
 
-#server:
-#  port: 19093
+server:
+  port: 19070


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #4

gitignore 설정에  문제가 있어 새로 프로젝트를 다시 생성하여 PR 올립니다  
이전 커밋을 확인해보고 싶으시면 아래의 이슈로 확인하시길 바랍니다.
#22 

## 📝 Description
주문 생성과 삭제에 RabbitMQ를 적용해보았습니다. 

- ### 주문 생성
![image](https://github.com/user-attachments/assets/dace3346-cf92-4b4b-8d80-b79129a032ce)
주문 생성시에 Product, Delivery에 각각 이벤트가 발생하며 발생한 이벤트는 메세지 큐에 저장됩니다.

- ### 주문 동적 조회
![image](https://github.com/user-attachments/assets/638e14ab-32e4-454e-a4bd-489cef0dd78d)
관리자 권한에 따른 서치를 동적으로 구현했습니다. 허브 관리자의 경우 해당 허브만 서치, 업체 관리자의 경우 해당 업체 서치,
배달 관리자의 경우 본인이 배정받은 주문에만 서치가 가능하도록 구현했습니다. 주문 목록 조회시 주문의 목록만 응답됩니다.
- ### 단건조회
![image](https://github.com/user-attachments/assets/f17e13bc-8fa3-461c-ac90-453654423f9d)
주문 목록에서 해당 주문의 권한에 따른 해당 유저에 대한 검증을 통해 세부사항을 조회시 주문 내용과 주문 품목에 대한 응답이 발생합니다. 

- ### 주문 삭제
![image](https://github.com/user-attachments/assets/863e8606-80fe-4117-932a-4153dd4ed1d2)
주문 삭제시 생성과 마찬가지로 Product, Delivery에 각각 이벤트가 발생하며 이벤트 큐에 저장됩니다.

## 💬 To Reivewers

- 리뷰 잘 부탁드립니다 👍 