### PR TITLE
Feign Client 허브 이동 정보 반환 추가 요구사항 반영

### DIFF
--- a/com.first-class.msa.hub/src/main/java/com/first_class/msa/hub/application/dto/transit/ResHubTransitInfoGetDTO.java
+++ b/com.first-class.msa.hub/src/main/java/com/first_class/msa/hub/application/dto/transit/ResHubTransitInfoGetDTO.java
@@ -29,7 +29,9 @@ public class ResHubTransitInfoGetDTO {
     public static class HubTransitInfoDTO {
 
         private Long departureHubId;
+        private String departureHubName;
         private Long arrivalHubId;
+        private String arrivalHubName;
         private Long transitTime;
         private double distance;
 
@@ -42,7 +44,9 @@ public class ResHubTransitInfoGetDTO {
         public static HubTransitInfoDTO from(HubTransitInfo hubTransitInfo) {
             return HubTransitInfoDTO.builder()
                     .departureHubId(hubTransitInfo.getDepartureHub().getId())
+                    .departureHubName(hubTransitInfo.getDepartureHub().getName())
                     .arrivalHubId(hubTransitInfo.getArrivalHub().getId())
+                    .arrivalHubName(hubTransitInfo.getArrivalHub().getName())
                     .transitTime(hubTransitInfo.getTransitTime())
                     .distance(hubTransitInfo.getDistance())
                     .build();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #45 

## 📝 Description

- Feign Client 허브 이동 정보 반환 추가 요구사항을 반영하였습니다.

```java
    public static class HubTransitInfoDTO {

        private Long departureHubId;
        private String departureHubName;
        private Long arrivalHubId;
        private String arrivalHubName;
        private Long transitTime;
        private double distance;
}
```
- 허브 이동 정보 조회 간 출발 및 도착 허브의 이름도 포함하여 반환하도록 하였습니다.